### PR TITLE
feat: update python-future to 0.18.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+python-future (0.18.2-6) unstable; urgency=medium
+
+  * Set upstream metadata fields: Repository, Repository-Browse.
+  * Remove constraints unnecessary since buster:
+    + Build-Depends: Drop versioned constraint on dh-python.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 25 May 2022 20:40:53 +0100
+
 python-future (0.18.2-5) unstable; urgency=medium
 
   * Team upload

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Debian Python Team <team+python@tracker.debian.org>
 Uploaders: Vincent Bernat <bernat@debian.org>
 Build-Depends: debhelper-compat (= 13),
-               dh-python (>= 2.20160609~),
+               dh-python,
                python3-all,
                python3-setuptools,
                python3-sphinx,

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,2 +1,4 @@
 Bug-Database: https://github.com/PythonCharmers/python-future/issues
 Bug-Submit: https://github.com/PythonCharmers/python-future/issues/new
+Repository: https://github.com/PythonCharmers/python-future.git
+Repository-Browse: https://github.com/PythonCharmers/python-future


### PR DESCRIPTION
Clean single-source support for Python 3 and 2 - Python 3.x

Issue: https://github.com/deepin-community/sig-deepin-sysdev-team/issues/552
Log: update repo
